### PR TITLE
Allow module to fail gracefully in prerender mode.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,7 @@
 let prefix = (function () {
+  if (typeof window === "undefined") {
+    return {};
+  }
   var styles = window.getComputedStyle(document.documentElement, ''),
     pre = (Array.prototype.slice
       .call(styles)
@@ -93,6 +96,9 @@ function flexbox(properties) {
 }
 
 function prefixStyles(styles) {
+  if (typeof window === "undefined") {
+    return styles;
+  }
   return Object.keys(styles).reduce((previous, current) => {
     previous[current] = flexbox(prefixStyle(styles[current]));
     return previous;


### PR DESCRIPTION
Hi. This module works well in development mode but throws an error attempting to use it on the server (window is undefined). This is a workaround for that use-case. If window is undefined the module simply passes the styles along.

Also not sure how you're compiling into `dist`, perhaps you can add a script for that in `package.json`?
